### PR TITLE
Exclude qtcreator local file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,12 +100,12 @@ background.tiff*
 
 # Qt Creator
 Makefile.am.user
-src/ecc.config
-src/ecc.creator
-src/ecc.creator.user
-src/ecc.files
-src/ecc.includes
-src/ecc.c*
+src/ecc*.config
+src/ecc*.creator
+src/ecc*.creator.user
+src/ecc*.files
+src/ecc*.includes
+src/ecc*.c*
 
 # Unit-tests
 Makefile.test

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -481,4 +481,4 @@ done
 
 end_time=$(date +%s%N)
 
-echo "Elapsed time: $(($(($end_time-$start_time))/1000000)) milliseconds"
+echo "Elapsed time: $(((end_time-start_time)/1000000)) milliseconds (~$(((end_time-start_time)/60000000000)) minutes)"


### PR DESCRIPTION
- Exclude qtcreator local file
- Fixed shellcheck sc2004 not valid